### PR TITLE
fix problem with debug symbols and pkg-config

### DIFF
--- a/dockers/ubuntu-18.04/Dockerfile
+++ b/dockers/ubuntu-18.04/Dockerfile
@@ -1,11 +1,12 @@
 FROM ubuntu:18.04
 
+ENV DEBIAN_FRONTEND noninteractive
+
 # install python3
 RUN apt-get update \
     && apt-get install --yes apt-utils python3 python3-pip sudo
 
 # install all debian packages up front (saves time for the development cycle of gst-conan codebase)
-ENV DEBIAN_FRONTEND noninteractive
 COPY dockers/ubuntu-18.04/debians.txt /tmp/debians.txt
 RUN apt-get install --yes $(cat /tmp/debians.txt | tr '\r\n' ' ' | tr '\n' ' ')
 RUN sudo apt-get clean
@@ -22,13 +23,23 @@ USER default_user
 # install stuff with pip (saves time for the development cycle of gst-conan codebase)
 RUN pip3 install setuptools wheel
 RUN pip3 install --user meson
-RUN pip3 install conan
 
-# make this folder owned by default_user
-#     otherwise, when it gets mounted during `docker run` the folder will be owned by root.
-RUN mkdir -p ~/.conan/data
+# The following 'conan' args must match the user's system.  We need to install the same version of conan as the user.
+# We must use the same storage folder as the user so that conan packages can be debugged by the consumer (debug symbols
+# will point to absolute paths on the system where compilation occurred).
+ARG CONAN_STORAGE_PATH
+ARG CONAN_VERSION
+
+ENV CONAN_STORAGE_PATH "$CONAN_STORAGE_PATH"
+
+RUN pip3 install conan==$CONAN_VERSION
 
 USER root
+
+# make this folder exists and is owned by default_user
+#     otherwise it would be owned by root when mounted from a `docker run` command.
+RUN mkdir -p "$CONAN_STORAGE_PATH"
+RUN chown -R default_user "$CONAN_STORAGE_PATH"
 
 # deploy gst-conan
 COPY config/ /opt/gst-conan/config
@@ -43,5 +54,8 @@ USER default_user
 RUN echo "\n\nPATH=\${HOME}/.local/bin:\${PATH}\n" >> ~/.bashrc
 ENV PATH=${PATH}:/opt/gst-conan
 
+# setup conan storage path
+RUN bash --login -c "conan config set storage.path=\"$CONAN_STORAGE_PATH\""
+
 ENTRYPOINT ["bash", "--login", "-c"]
-CMD ["bash"]
+CMD ["echo", "hello world"]

--- a/gst_conan/base/__init__.py
+++ b/gst_conan/base/__init__.py
@@ -24,9 +24,6 @@ def basenames(filenames:list) -> list:
 
     return output
 
-def conanDataFolderWithinDockerContainers() -> str:
-    return "/home/default_user/.conan/data"
-
 def currentUserIsPrivileged() -> bool:
     '''
     Determines whether the user has root (on linux) or administrative (on windows) privileges.

--- a/gst_conan/build/PkgConfigFile.py
+++ b/gst_conan/build/PkgConfigFile.py
@@ -51,6 +51,34 @@ class PkgConfigFile:
         # Variables
         self.variables = odict()
 
+    def ensureRequires(self, requirement) -> None:
+        '''
+        Ensures the requirement is part of self.requires
+        :param requirement: The requirement (string) or list of requirements (set, list, tuple)
+        :return: Nothing
+        '''
+        if isinstance(requirement, (list, tuple, set)):
+            for r in requirement:
+                self.ensureRequires(r)
+        elif self.requires == None or len(self.requires) == 0:
+            self.requires = requirement
+        elif requirement not in self.requires:
+            self.requires += (" " + requirement)
+
+    def ensureRequiresPrivate(self, requirement) -> None:
+        '''
+        Ensures the requirement is part of self.requiresPrivate
+        :param requirement: The requirement (string) or list of requirements (set, list, tuple)
+        :return: Nothing
+        '''
+        if isinstance(requirement, (list, tuple, set)):
+            for r in requirement:
+                self.ensureRequiresPrivate(r)
+        elif self.requiresPrivate == None or len(self.requiresPrivate) == 0:
+            self.requiresPrivate = requirement
+        elif requirement not in self.requiresPrivate:
+            self.requiresPrivate += (" " + requirement)
+
     def load(self, filename:str):
         with open(filename, "r") as reader:
             for rawLine in reader:

--- a/gst_conan/build/__init__.py
+++ b/gst_conan/build/__init__.py
@@ -20,6 +20,16 @@ def conanBuildTypes() -> list:
     '''
     return ["Debug", "Release"]
 
+def conanVersion() -> str:
+    # Here we don't use conans.__version__ because the library version may be different than the version on the path.
+    spew = base.evaluate("conan --version")
+    idx = spew.rfind(" ")+1
+    output = spew[idx:]
+    return output
+
+def conanStorageFolder() -> str:
+    return base.evaluate("conan config get storage.path")
+
 def copyFiles(pattern:str, srcFolder:str, destFolder:str, keepPath:bool=True) -> list:
     '''
     Copies files having a specified pattern within the source folder.  This function exists because I had problems using

--- a/packages/gst-editing-services/gst_conan/base/__init__.py
+++ b/packages/gst-editing-services/gst_conan/base/__init__.py
@@ -24,9 +24,6 @@ def basenames(filenames:list) -> list:
 
     return output
 
-def conanDataFolderWithinDockerContainers() -> str:
-    return "/home/default_user/.conan/data"
-
 def currentUserIsPrivileged() -> bool:
     '''
     Determines whether the user has root (on linux) or administrative (on windows) privileges.

--- a/packages/gst-editing-services/gst_conan/build/PkgConfigFile.py
+++ b/packages/gst-editing-services/gst_conan/build/PkgConfigFile.py
@@ -51,6 +51,34 @@ class PkgConfigFile:
         # Variables
         self.variables = odict()
 
+    def ensureRequires(self, requirement) -> None:
+        '''
+        Ensures the requirement is part of self.requires
+        :param requirement: The requirement (string) or list of requirements (set, list, tuple)
+        :return: Nothing
+        '''
+        if isinstance(requirement, (list, tuple, set)):
+            for r in requirement:
+                self.ensureRequires(r)
+        elif self.requires == None or len(self.requires) == 0:
+            self.requires = requirement
+        elif requirement not in self.requires:
+            self.requires += (" " + requirement)
+
+    def ensureRequiresPrivate(self, requirement) -> None:
+        '''
+        Ensures the requirement is part of self.requiresPrivate
+        :param requirement: The requirement (string) or list of requirements (set, list, tuple)
+        :return: Nothing
+        '''
+        if isinstance(requirement, (list, tuple, set)):
+            for r in requirement:
+                self.ensureRequiresPrivate(r)
+        elif self.requiresPrivate == None or len(self.requiresPrivate) == 0:
+            self.requiresPrivate = requirement
+        elif requirement not in self.requiresPrivate:
+            self.requiresPrivate += (" " + requirement)
+
     def load(self, filename:str):
         with open(filename, "r") as reader:
             for rawLine in reader:

--- a/packages/gst-editing-services/gst_conan/build/__init__.py
+++ b/packages/gst-editing-services/gst_conan/build/__init__.py
@@ -20,6 +20,16 @@ def conanBuildTypes() -> list:
     '''
     return ["Debug", "Release"]
 
+def conanVersion() -> str:
+    # Here we don't use conans.__version__ because the library version may be different than the version on the path.
+    spew = base.evaluate("conan --version")
+    idx = spew.rfind(" ")+1
+    output = spew[idx:]
+    return output
+
+def conanStorageFolder() -> str:
+    return base.evaluate("conan config get storage.path")
+
 def copyFiles(pattern:str, srcFolder:str, destFolder:str, keepPath:bool=True) -> list:
     '''
     Copies files having a specified pattern within the source folder.  This function exists because I had problems using

--- a/packages/gst-libav/gst_conan/base/__init__.py
+++ b/packages/gst-libav/gst_conan/base/__init__.py
@@ -24,9 +24,6 @@ def basenames(filenames:list) -> list:
 
     return output
 
-def conanDataFolderWithinDockerContainers() -> str:
-    return "/home/default_user/.conan/data"
-
 def currentUserIsPrivileged() -> bool:
     '''
     Determines whether the user has root (on linux) or administrative (on windows) privileges.

--- a/packages/gst-libav/gst_conan/build/PkgConfigFile.py
+++ b/packages/gst-libav/gst_conan/build/PkgConfigFile.py
@@ -51,6 +51,34 @@ class PkgConfigFile:
         # Variables
         self.variables = odict()
 
+    def ensureRequires(self, requirement) -> None:
+        '''
+        Ensures the requirement is part of self.requires
+        :param requirement: The requirement (string) or list of requirements (set, list, tuple)
+        :return: Nothing
+        '''
+        if isinstance(requirement, (list, tuple, set)):
+            for r in requirement:
+                self.ensureRequires(r)
+        elif self.requires == None or len(self.requires) == 0:
+            self.requires = requirement
+        elif requirement not in self.requires:
+            self.requires += (" " + requirement)
+
+    def ensureRequiresPrivate(self, requirement) -> None:
+        '''
+        Ensures the requirement is part of self.requiresPrivate
+        :param requirement: The requirement (string) or list of requirements (set, list, tuple)
+        :return: Nothing
+        '''
+        if isinstance(requirement, (list, tuple, set)):
+            for r in requirement:
+                self.ensureRequiresPrivate(r)
+        elif self.requiresPrivate == None or len(self.requiresPrivate) == 0:
+            self.requiresPrivate = requirement
+        elif requirement not in self.requiresPrivate:
+            self.requiresPrivate += (" " + requirement)
+
     def load(self, filename:str):
         with open(filename, "r") as reader:
             for rawLine in reader:

--- a/packages/gst-libav/gst_conan/build/__init__.py
+++ b/packages/gst-libav/gst_conan/build/__init__.py
@@ -20,6 +20,16 @@ def conanBuildTypes() -> list:
     '''
     return ["Debug", "Release"]
 
+def conanVersion() -> str:
+    # Here we don't use conans.__version__ because the library version may be different than the version on the path.
+    spew = base.evaluate("conan --version")
+    idx = spew.rfind(" ")+1
+    output = spew[idx:]
+    return output
+
+def conanStorageFolder() -> str:
+    return base.evaluate("conan config get storage.path")
+
 def copyFiles(pattern:str, srcFolder:str, destFolder:str, keepPath:bool=True) -> list:
     '''
     Copies files having a specified pattern within the source folder.  This function exists because I had problems using

--- a/packages/gst-plugins-bad/gst_conan/base/__init__.py
+++ b/packages/gst-plugins-bad/gst_conan/base/__init__.py
@@ -24,9 +24,6 @@ def basenames(filenames:list) -> list:
 
     return output
 
-def conanDataFolderWithinDockerContainers() -> str:
-    return "/home/default_user/.conan/data"
-
 def currentUserIsPrivileged() -> bool:
     '''
     Determines whether the user has root (on linux) or administrative (on windows) privileges.

--- a/packages/gst-plugins-bad/gst_conan/build/PkgConfigFile.py
+++ b/packages/gst-plugins-bad/gst_conan/build/PkgConfigFile.py
@@ -51,6 +51,34 @@ class PkgConfigFile:
         # Variables
         self.variables = odict()
 
+    def ensureRequires(self, requirement) -> None:
+        '''
+        Ensures the requirement is part of self.requires
+        :param requirement: The requirement (string) or list of requirements (set, list, tuple)
+        :return: Nothing
+        '''
+        if isinstance(requirement, (list, tuple, set)):
+            for r in requirement:
+                self.ensureRequires(r)
+        elif self.requires == None or len(self.requires) == 0:
+            self.requires = requirement
+        elif requirement not in self.requires:
+            self.requires += (" " + requirement)
+
+    def ensureRequiresPrivate(self, requirement) -> None:
+        '''
+        Ensures the requirement is part of self.requiresPrivate
+        :param requirement: The requirement (string) or list of requirements (set, list, tuple)
+        :return: Nothing
+        '''
+        if isinstance(requirement, (list, tuple, set)):
+            for r in requirement:
+                self.ensureRequiresPrivate(r)
+        elif self.requiresPrivate == None or len(self.requiresPrivate) == 0:
+            self.requiresPrivate = requirement
+        elif requirement not in self.requiresPrivate:
+            self.requiresPrivate += (" " + requirement)
+
     def load(self, filename:str):
         with open(filename, "r") as reader:
             for rawLine in reader:

--- a/packages/gst-plugins-bad/gst_conan/build/__init__.py
+++ b/packages/gst-plugins-bad/gst_conan/build/__init__.py
@@ -20,6 +20,16 @@ def conanBuildTypes() -> list:
     '''
     return ["Debug", "Release"]
 
+def conanVersion() -> str:
+    # Here we don't use conans.__version__ because the library version may be different than the version on the path.
+    spew = base.evaluate("conan --version")
+    idx = spew.rfind(" ")+1
+    output = spew[idx:]
+    return output
+
+def conanStorageFolder() -> str:
+    return base.evaluate("conan config get storage.path")
+
 def copyFiles(pattern:str, srcFolder:str, destFolder:str, keepPath:bool=True) -> list:
     '''
     Copies files having a specified pattern within the source folder.  This function exists because I had problems using

--- a/packages/gst-plugins-base/conanfile.py
+++ b/packages/gst-plugins-base/conanfile.py
@@ -48,10 +48,14 @@ class GstPluginsBaseConan(ConanFile):
         pc = gst_conan.build.PkgConfigFile()
         pc.load(pkgConfigFile)
 
-        requirements = ["  gstreamer-audio-1.0", " gstreamer-tag-1.0"]
-        for requirement in requirements:
-            if requirement not in pc.requires:
-                pc.requires += requirement
+        pc.ensureRequires(["gstreamer-audio-1.0", "gstreamer-base-1.0", "gstreamer-video-1.0", "gstreamer-tag-1.0"])
+
+        #requirements = ["gstreamer-tag-1.0"]
+        #for requirement in requirements:
+        #    if pc.requiresPrivate == None or len(pc.requiresPrivate) == 0:
+        #        pc.requiresPrivate = requirement
+        #    elif requirement not in pc.requiresPrivate:
+        #        pc.requiresPrivate += (" " + requirement)
 
         pc.save(pkgConfigFile)
 

--- a/packages/gst-plugins-base/gst_conan/base/__init__.py
+++ b/packages/gst-plugins-base/gst_conan/base/__init__.py
@@ -24,9 +24,6 @@ def basenames(filenames:list) -> list:
 
     return output
 
-def conanDataFolderWithinDockerContainers() -> str:
-    return "/home/default_user/.conan/data"
-
 def currentUserIsPrivileged() -> bool:
     '''
     Determines whether the user has root (on linux) or administrative (on windows) privileges.

--- a/packages/gst-plugins-base/gst_conan/build/PkgConfigFile.py
+++ b/packages/gst-plugins-base/gst_conan/build/PkgConfigFile.py
@@ -51,6 +51,34 @@ class PkgConfigFile:
         # Variables
         self.variables = odict()
 
+    def ensureRequires(self, requirement) -> None:
+        '''
+        Ensures the requirement is part of self.requires
+        :param requirement: The requirement (string) or list of requirements (set, list, tuple)
+        :return: Nothing
+        '''
+        if isinstance(requirement, (list, tuple, set)):
+            for r in requirement:
+                self.ensureRequires(r)
+        elif self.requires == None or len(self.requires) == 0:
+            self.requires = requirement
+        elif requirement not in self.requires:
+            self.requires += (" " + requirement)
+
+    def ensureRequiresPrivate(self, requirement) -> None:
+        '''
+        Ensures the requirement is part of self.requiresPrivate
+        :param requirement: The requirement (string) or list of requirements (set, list, tuple)
+        :return: Nothing
+        '''
+        if isinstance(requirement, (list, tuple, set)):
+            for r in requirement:
+                self.ensureRequiresPrivate(r)
+        elif self.requiresPrivate == None or len(self.requiresPrivate) == 0:
+            self.requiresPrivate = requirement
+        elif requirement not in self.requiresPrivate:
+            self.requiresPrivate += (" " + requirement)
+
     def load(self, filename:str):
         with open(filename, "r") as reader:
             for rawLine in reader:

--- a/packages/gst-plugins-base/gst_conan/build/__init__.py
+++ b/packages/gst-plugins-base/gst_conan/build/__init__.py
@@ -20,6 +20,16 @@ def conanBuildTypes() -> list:
     '''
     return ["Debug", "Release"]
 
+def conanVersion() -> str:
+    # Here we don't use conans.__version__ because the library version may be different than the version on the path.
+    spew = base.evaluate("conan --version")
+    idx = spew.rfind(" ")+1
+    output = spew[idx:]
+    return output
+
+def conanStorageFolder() -> str:
+    return base.evaluate("conan config get storage.path")
+
 def copyFiles(pattern:str, srcFolder:str, destFolder:str, keepPath:bool=True) -> list:
     '''
     Copies files having a specified pattern within the source folder.  This function exists because I had problems using

--- a/packages/gst-plugins-good/gst_conan/base/__init__.py
+++ b/packages/gst-plugins-good/gst_conan/base/__init__.py
@@ -24,9 +24,6 @@ def basenames(filenames:list) -> list:
 
     return output
 
-def conanDataFolderWithinDockerContainers() -> str:
-    return "/home/default_user/.conan/data"
-
 def currentUserIsPrivileged() -> bool:
     '''
     Determines whether the user has root (on linux) or administrative (on windows) privileges.

--- a/packages/gst-plugins-good/gst_conan/build/PkgConfigFile.py
+++ b/packages/gst-plugins-good/gst_conan/build/PkgConfigFile.py
@@ -51,6 +51,34 @@ class PkgConfigFile:
         # Variables
         self.variables = odict()
 
+    def ensureRequires(self, requirement) -> None:
+        '''
+        Ensures the requirement is part of self.requires
+        :param requirement: The requirement (string) or list of requirements (set, list, tuple)
+        :return: Nothing
+        '''
+        if isinstance(requirement, (list, tuple, set)):
+            for r in requirement:
+                self.ensureRequires(r)
+        elif self.requires == None or len(self.requires) == 0:
+            self.requires = requirement
+        elif requirement not in self.requires:
+            self.requires += (" " + requirement)
+
+    def ensureRequiresPrivate(self, requirement) -> None:
+        '''
+        Ensures the requirement is part of self.requiresPrivate
+        :param requirement: The requirement (string) or list of requirements (set, list, tuple)
+        :return: Nothing
+        '''
+        if isinstance(requirement, (list, tuple, set)):
+            for r in requirement:
+                self.ensureRequiresPrivate(r)
+        elif self.requiresPrivate == None or len(self.requiresPrivate) == 0:
+            self.requiresPrivate = requirement
+        elif requirement not in self.requiresPrivate:
+            self.requiresPrivate += (" " + requirement)
+
     def load(self, filename:str):
         with open(filename, "r") as reader:
             for rawLine in reader:

--- a/packages/gst-plugins-good/gst_conan/build/__init__.py
+++ b/packages/gst-plugins-good/gst_conan/build/__init__.py
@@ -20,6 +20,16 @@ def conanBuildTypes() -> list:
     '''
     return ["Debug", "Release"]
 
+def conanVersion() -> str:
+    # Here we don't use conans.__version__ because the library version may be different than the version on the path.
+    spew = base.evaluate("conan --version")
+    idx = spew.rfind(" ")+1
+    output = spew[idx:]
+    return output
+
+def conanStorageFolder() -> str:
+    return base.evaluate("conan config get storage.path")
+
 def copyFiles(pattern:str, srcFolder:str, destFolder:str, keepPath:bool=True) -> list:
     '''
     Copies files having a specified pattern within the source folder.  This function exists because I had problems using

--- a/packages/gst-plugins-ugly/gst_conan/base/__init__.py
+++ b/packages/gst-plugins-ugly/gst_conan/base/__init__.py
@@ -24,9 +24,6 @@ def basenames(filenames:list) -> list:
 
     return output
 
-def conanDataFolderWithinDockerContainers() -> str:
-    return "/home/default_user/.conan/data"
-
 def currentUserIsPrivileged() -> bool:
     '''
     Determines whether the user has root (on linux) or administrative (on windows) privileges.

--- a/packages/gst-plugins-ugly/gst_conan/build/PkgConfigFile.py
+++ b/packages/gst-plugins-ugly/gst_conan/build/PkgConfigFile.py
@@ -51,6 +51,34 @@ class PkgConfigFile:
         # Variables
         self.variables = odict()
 
+    def ensureRequires(self, requirement) -> None:
+        '''
+        Ensures the requirement is part of self.requires
+        :param requirement: The requirement (string) or list of requirements (set, list, tuple)
+        :return: Nothing
+        '''
+        if isinstance(requirement, (list, tuple, set)):
+            for r in requirement:
+                self.ensureRequires(r)
+        elif self.requires == None or len(self.requires) == 0:
+            self.requires = requirement
+        elif requirement not in self.requires:
+            self.requires += (" " + requirement)
+
+    def ensureRequiresPrivate(self, requirement) -> None:
+        '''
+        Ensures the requirement is part of self.requiresPrivate
+        :param requirement: The requirement (string) or list of requirements (set, list, tuple)
+        :return: Nothing
+        '''
+        if isinstance(requirement, (list, tuple, set)):
+            for r in requirement:
+                self.ensureRequiresPrivate(r)
+        elif self.requiresPrivate == None or len(self.requiresPrivate) == 0:
+            self.requiresPrivate = requirement
+        elif requirement not in self.requiresPrivate:
+            self.requiresPrivate += (" " + requirement)
+
     def load(self, filename:str):
         with open(filename, "r") as reader:
             for rawLine in reader:

--- a/packages/gst-plugins-ugly/gst_conan/build/__init__.py
+++ b/packages/gst-plugins-ugly/gst_conan/build/__init__.py
@@ -20,6 +20,16 @@ def conanBuildTypes() -> list:
     '''
     return ["Debug", "Release"]
 
+def conanVersion() -> str:
+    # Here we don't use conans.__version__ because the library version may be different than the version on the path.
+    spew = base.evaluate("conan --version")
+    idx = spew.rfind(" ")+1
+    output = spew[idx:]
+    return output
+
+def conanStorageFolder() -> str:
+    return base.evaluate("conan config get storage.path")
+
 def copyFiles(pattern:str, srcFolder:str, destFolder:str, keepPath:bool=True) -> list:
     '''
     Copies files having a specified pattern within the source folder.  This function exists because I had problems using

--- a/packages/gstreamer/gst_conan/base/__init__.py
+++ b/packages/gstreamer/gst_conan/base/__init__.py
@@ -24,9 +24,6 @@ def basenames(filenames:list) -> list:
 
     return output
 
-def conanDataFolderWithinDockerContainers() -> str:
-    return "/home/default_user/.conan/data"
-
 def currentUserIsPrivileged() -> bool:
     '''
     Determines whether the user has root (on linux) or administrative (on windows) privileges.

--- a/packages/gstreamer/gst_conan/build/PkgConfigFile.py
+++ b/packages/gstreamer/gst_conan/build/PkgConfigFile.py
@@ -51,6 +51,34 @@ class PkgConfigFile:
         # Variables
         self.variables = odict()
 
+    def ensureRequires(self, requirement) -> None:
+        '''
+        Ensures the requirement is part of self.requires
+        :param requirement: The requirement (string) or list of requirements (set, list, tuple)
+        :return: Nothing
+        '''
+        if isinstance(requirement, (list, tuple, set)):
+            for r in requirement:
+                self.ensureRequires(r)
+        elif self.requires == None or len(self.requires) == 0:
+            self.requires = requirement
+        elif requirement not in self.requires:
+            self.requires += (" " + requirement)
+
+    def ensureRequiresPrivate(self, requirement) -> None:
+        '''
+        Ensures the requirement is part of self.requiresPrivate
+        :param requirement: The requirement (string) or list of requirements (set, list, tuple)
+        :return: Nothing
+        '''
+        if isinstance(requirement, (list, tuple, set)):
+            for r in requirement:
+                self.ensureRequiresPrivate(r)
+        elif self.requiresPrivate == None or len(self.requiresPrivate) == 0:
+            self.requiresPrivate = requirement
+        elif requirement not in self.requiresPrivate:
+            self.requiresPrivate += (" " + requirement)
+
     def load(self, filename:str):
         with open(filename, "r") as reader:
             for rawLine in reader:

--- a/packages/gstreamer/gst_conan/build/__init__.py
+++ b/packages/gstreamer/gst_conan/build/__init__.py
@@ -20,6 +20,16 @@ def conanBuildTypes() -> list:
     '''
     return ["Debug", "Release"]
 
+def conanVersion() -> str:
+    # Here we don't use conans.__version__ because the library version may be different than the version on the path.
+    spew = base.evaluate("conan --version")
+    idx = spew.rfind(" ")+1
+    output = spew[idx:]
+    return output
+
+def conanStorageFolder() -> str:
+    return base.evaluate("conan config get storage.path")
+
 def copyFiles(pattern:str, srcFolder:str, destFolder:str, keepPath:bool=True) -> list:
     '''
     Copies files having a specified pattern within the source folder.  This function exists because I had problems using

--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,8 @@
 This is a tool for building [Gstreamer](https://gstreamer.freedesktop.org/) components as [Conan](https://conan.io/) packages
 using the [Meson](https://mesonbuild.com/) build scripts which are included in the Gstreamer repositories.
 
+This is the tool used to the conan packages listed in [our repo on bintray](https://bintray.com/panopto-oss/gst-conan).
+
 ## Machine setup instructions
 
 First time users should look at the [machine setup instructions](doc/machine-setup.md).
@@ -14,7 +16,7 @@ In the future it may work on Mac and Windows, but this is a long ways off.
 
 ## Status
 
-This tool can create 6 conan packages:
+This tool can help you create many conan packages:
 
  * [gstreamer](https://github.com/gstreamer/gstreamer)
  * [gst-plugins-base](https://github.com/gstreamer/gst-plugins-base)
@@ -57,7 +59,7 @@ local Conan repo.
 ./gst-conan create --docker ubuntu-18.04 --rev 1.14.4 --version 1.14.4 --build_type Debug --user my_conan_user --channel my_conan_channel --keep-source
 ```
 
-#### Need to debug the build?
+#### Need to debug the docker container?
 You can poke around inside the docker container as follows where the conan storage folder on your host machine
 (`~/.conan/data` by default) is denoted as `$CONAN_STORAGE_FOLDER`. 
 
@@ -65,8 +67,11 @@ You can poke around inside the docker container as follows where the conan stora
 docker run -it --mount type=bind,src=$CONAN_STORAGE_FOLDER,dst=$CONAN_STORAGE_FOLDER gst-conan_ubuntu-18.04:latest 'bash'
 ```
 
-Note that in the expression above, the `CONAN_STORAGE_FOLDER` is the same on the host machine and inside the docker
-container.  This is done so that users can consume the debug symbols in a way that points their debugger the location of
+The expression above reveals how the `CONAN_STORAGE_FOLDER` is the same on the host machine and inside the docker container.
+There are at least 2 reasons why this is required.
+
+1.  For correct linkage to `pkg-config` files (and between them).
+2.  So that users can consume the debug symbols in a way that points their debugger the location of
 the source code on the host machine. 
 
 ### How to create the Conan packages without Docker (not recommend)
@@ -106,6 +111,12 @@ Perform the upload.
 
 ```bash
 conan upload --check --confirm --remote panopto-oss gst*/$GIT_TAG
+```
+
+Make sure the tag does not already apply to any other commits.
+```bash
+git tag --delete $GIT_TAG          # local
+git push --delete origin $GIT_TAG  # remote
 ```
 
 Tag the relevant `git` commit. 

--- a/readme.md
+++ b/readme.md
@@ -58,11 +58,16 @@ local Conan repo.
 ```
 
 #### Need to debug the build?
-You can poke around inside the docker container like this:
+You can poke around inside the docker container as follows where the conan storage folder on your host machine
+(`~/.conan/data` by default) is denoted as `$CONAN_STORAGE_FOLDER`. 
 
 ```bash
-docker run -it --mount type=bind,src=$HOME/.conan/data,dst=/home/default_user/.conan/data gst-conan_ubuntu-18.04:latest 'bash'
+docker run -it --mount type=bind,src=$CONAN_STORAGE_FOLDER,dst=$CONAN_STORAGE_FOLDER gst-conan_ubuntu-18.04:latest 'bash'
 ```
+
+Note that in the expression above, the `CONAN_STORAGE_FOLDER` is the same on the host machine and inside the docker
+container.  This is done so that users can consume the debug symbols in a way that points their debugger the location of
+the source code on the host machine. 
 
 ### How to create the Conan packages without Docker (not recommend)
 


### PR DESCRIPTION
This fixes [a problem](https://github.com/Panopto/gst-conan/issues/5) which prevented me from debugging the internals of gstreamer on my dev machine.

The path to the `CONAN_STORAGE_FOLDER` must be the same on the host machine and inside the docker container.

I also made sure the version of conan was the same on the host machine and inside the docker container.

Testing:  I can debug the internals of gstreamer now.